### PR TITLE
Update vasp.md

### DIFF
--- a/docs/computing/vasp.md
+++ b/docs/computing/vasp.md
@@ -63,7 +63,7 @@ direct
 :::
 
 :::{tab-item} POTCAR
-POTCAR gives the poeudopotential.
+POTCAR gives the pseudopotential.
 
 POTCAR is proprietary, and we cannot list it publicly. To get it, on `Carya`, copy `/project/wen/commons/vasp/pp/potpaw_PBE_54/Si/POTCAR` to your directory.
 


### PR DESCRIPTION
Fix a typo in "POTCAR gives the poeudopotential", p"o"eudopotential > p"s"eudopotentials